### PR TITLE
fixed crash when water groundpounding and cancelling on the same frame

### DIFF
--- a/src/game/mario_actions_submerged.c
+++ b/src/game/mario_actions_submerged.c
@@ -814,7 +814,6 @@ static s32 act_water_throw(struct MarioState *m) {
 
 s32 act_water_ground_pound(struct MarioState *m) {
     u32 stepResult;
-    f32 yOffset;
 
     play_sound_if_no_flag(m, SOUND_ACTION_THROW, MARIO_ACTION_SOUND_PLAYED);
 
@@ -845,10 +844,8 @@ s32 act_water_ground_pound(struct MarioState *m) {
         stepResult = perform_water_step(m);
         if (stepResult == WATER_STEP_HIT_FLOOR) {
             play_mario_heavy_landing_sound(m, SOUND_ACTION_TERRAIN_HEAVY_LANDING);
-            if (!check_fall_damage(m, ACT_HARD_BACKWARD_GROUND_KB)) {
-                m->particleFlags |= PARTICLE_MIST_CIRCLE;
-                set_mario_action(m, ACT_WATER_IDLE, 0);
-            }
+            m->particleFlags |= PARTICLE_MIST_CIRCLE;
+            set_mario_action(m, ACT_WATER_IDLE, 0);
             set_camera_shake_from_hit(SHAKE_GROUND_POUND);
         } else if (stepResult == WATER_STEP_HIT_WALL) {
             if (m->vel[1] > 0.0f) {
@@ -861,10 +858,8 @@ s32 act_water_ground_pound(struct MarioState *m) {
         stepResult = perform_water_step(m);
         if (stepResult == WATER_STEP_HIT_FLOOR) {
             play_mario_heavy_landing_sound(m, SOUND_ACTION_TERRAIN_HEAVY_LANDING);
-            if (!check_fall_damage(m, ACT_HARD_BACKWARD_GROUND_KB)) {
-                m->particleFlags |= PARTICLE_MIST_CIRCLE;
-                set_mario_action(m, ACT_WATER_IDLE, 0);
-            }
+            m->particleFlags |= PARTICLE_MIST_CIRCLE;
+            set_mario_action(m, ACT_WATER_IDLE, 0);
             set_camera_shake_from_hit(SHAKE_GROUND_POUND);
         } else if (stepResult == WATER_STEP_HIT_WALL) {
             if (m->vel[1] > 0.0f) {


### PR DESCRIPTION
So yeah.. just found out that this causes a crash in Lucy's, and it turns out it causes a crash here too! Also added the ability to cancel out of a water ground pound with the B button too.

Also removed the little height boost from the water groundpound because you can keep spamming it, causing you to rise up through collision. I don't think the height boost is that necessary anyways.