### PR TITLE
Get cycle and more

### DIFF
--- a/include/config/config_rom.h
+++ b/include/config/config_rom.h
@@ -34,4 +34,4 @@
 /**
  * Informs supported emulators to default to gamecube controller inputs.
  */
- #define USE_GAMECUBE_CONTROLLER
+//  #define USE_GAMECUBE_CONTROLLER

--- a/src/engine/math_util.c
+++ b/src/engine/math_util.c
@@ -1609,7 +1609,7 @@ void mtxf_to_mtx_fast(s16* dst, float* src)
  * @param timer s32: the timer source that should increment once per frame (e.g. gGlobalTimer)
  * @return f32: number between [-1, 1] for your cycle
  */
-f32 get_cycle(f32 cycleLength, f32 cycleOffset, u32 timer) {
+f32 get_cycle(f32 cycleLength, f32 cycleOffset, s32 timer) {
     f32 rate = (f32)DEGREES(360/30) * (1.0f/cycleLength);
     f32 offset = (f32)DEGREES(360) * cycleOffset;
     return sins(roundf((rate * (f32)timer) + offset));

--- a/src/engine/math_util.h
+++ b/src/engine/math_util.h
@@ -617,7 +617,7 @@ void mtxf_rot_trans_mul(Vec3s rot, Vec3f trans, Mat4 dest, Mat4 src);
 void find_surface_on_ray(Vec3f orig, Vec3f dir, struct Surface **hit_surface, Vec3f hit_pos, s32 flags);
 void surface_center(Vec3f dest, Vec3s vtx1, Vec3s vtx2, Vec3s vtx3);
 void vec3f_center(Vec3f dest, Vec3f v1, Vec3f v2);
-f32 get_cycle(f32 cycleLength, f32 cycleOffset, u32 timer);
+f32 get_cycle(f32 cycleLength, f32 cycleOffset, s32 timer);
 
 #define copy_vec3(vec) { vec[0], vec[1], vec[2] }
 

--- a/src/game/area.c
+++ b/src/game/area.c
@@ -27,6 +27,7 @@
 #include "engine/colors.h"
 #include "profiling.h"
 #include "main.h"
+#include "menu/cozy_file_select.h"
 
 struct SpawnInfo gPlayerSpawnInfos[1];
 struct GraphNode *gGraphNodePointers[MODEL_ID_COUNT];
@@ -410,6 +411,9 @@ void render_game(void) {
         gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, gBorderHeight, gScreenWidth,
                       gScreenHeight - gBorderHeight);
         render_hud();
+        if (gRenderingFileSelect && gCurrLevelNum == LEVEL_UNKNOWN_1) {
+            render_file_select();
+        }
 
         gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, 0, gScreenWidth, gScreenHeight);
         render_text_labels();

--- a/src/game/behaviors/thecozies_water_switch.inc.c
+++ b/src/game/behaviors/thecozies_water_switch.inc.c
@@ -290,7 +290,7 @@ void whirlpool_life_cycle(struct Object *obj) {
             && gMarioState->water->object == obj
             && (ACT_GROUP_SUBMERGED == (gMarioState->action & ACT_GROUP_MASK))
         ) {
-            set_mario_action(gMarioState, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            set_mario_action(gMarioState, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x200);
         }
     }
 

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -667,6 +667,27 @@ s32 get_string_width(u8 *str) {
     return width;
 }
 
+// accounts for newlines, gets max width plus height
+// void get_string_dimensions(u8 *str, Vec2s dimensions) {
+//     s16 strPos = 0;
+
+//     dimensions[0] = 0; // line height apparently
+//     dimensions[1] = MAX_STRING_WIDTH; // line height apparently
+//     s16 width = 0;
+
+//     while (str[strPos] != DIALOG_CHAR_TERMINATOR) {
+//         if (str[strPos] == '\n') {
+//             if (width > dimensions[0]) dimensions[0] = width;
+//             width = 0;
+//             dimensions[1] += MAX_STRING_WIDTH;
+//             strPos++;
+//             continue;
+//         }
+//         width += gDialogCharWidths[str[strPos]];
+//         strPos++;
+//     }
+// }
+
 
 void print_hud_my_score_coins(s32 useCourseCoinScore, s8 fileIndex, s8 courseIndex, s16 x, s16 y) {
     u8 strNumCoins[4];

--- a/src/game/ingame_menu.h
+++ b/src/game/ingame_menu.h
@@ -242,6 +242,7 @@ void render_hub_level_confirmation();
 void end_results_loop(void);
 void shade_screen_amount(int amount);
 void shade_screen_col(int r, int g, int b, int a);
+// void get_string_dimensions(u8 *str, Vec2s dimensions);
 
 extern s32 gWorldID;
 extern s32 gFocusID;

--- a/src/game/mario.h
+++ b/src/game/mario.h
@@ -67,4 +67,8 @@ s32 get_checkpoint_action(struct MarioState *m);
 void check_mario_floor_checkpoint(struct MarioState *m);
 s32 warp_to_checkpoint(struct MarioState *m, s32 damage);
 
+ALWAYS_INLINE u32 collide_with_hurt_floor(struct MarioState *m) {
+    return set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, HURT_FLOOR_DAMAGE*0x100);
+}
+
 #endif // MARIO_H

--- a/src/game/mario_actions_airborne.c
+++ b/src/game/mario_actions_airborne.c
@@ -453,7 +453,7 @@ u32 common_air_action_step(struct MarioState *m, u32 landAction, s32 animation, 
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
 
     }
@@ -718,7 +718,7 @@ s32 act_riding_shell_air(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -774,7 +774,7 @@ s32 act_twirling(struct MarioState *m) {
             break;
         
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -854,7 +854,7 @@ s32 act_dive(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -890,7 +890,7 @@ s32 act_air_throw(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -935,7 +935,7 @@ s32 act_hold_water_jump(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -972,7 +972,7 @@ s32 act_steep_jump(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1159,7 +1159,7 @@ s32 act_crazy_box_bounce(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1214,7 +1214,7 @@ u32 common_air_knockback_step(struct MarioState *m, u32 landAction, u32 hardFall
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1434,7 +1434,7 @@ s32 act_forward_rollout(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1483,7 +1483,7 @@ s32 act_backward_rollout(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1528,7 +1528,7 @@ s32 act_butt_slide_air(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1577,7 +1577,7 @@ s32 act_hold_butt_slide_air(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1638,7 +1638,7 @@ s32 act_lava_boost(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1715,7 +1715,7 @@ s32 act_slide_kick(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1802,7 +1802,7 @@ s32 act_shot_from_cannon(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -1931,7 +1931,7 @@ s32 act_flying(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 
@@ -2056,7 +2056,7 @@ s32 act_flying_triple_jump(struct MarioState *m) {
             break;
 
         case AIR_STEP_HIT_HURT_WALL:
-            set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+            collide_with_hurt_floor(m);
             break;
     }
 

--- a/src/game/mario_actions_submerged.c
+++ b/src/game/mario_actions_submerged.c
@@ -135,7 +135,7 @@ static u32 perform_water_full_step(struct MarioState *m, Vec3f nextPos) {
                         || obj_has_behavior(ceil->object, bhvTubeTop)
                     )
                 ) {
-                    set_mario_action(m, ACT_FLOOR_CHECKPOINT_WARP_OUT, 0x100);
+                    collide_with_hurt_floor(m);
                     return WATER_STEP_CANCELLED;
                 }
             }

--- a/src/game/texscroll.c
+++ b/src/game/texscroll.c
@@ -116,13 +116,4 @@ void scroll_textures() {
 	if(SCROLL_CONDITION(sSegmentROMTable[0x7] == (uintptr_t)_pss_segment_7SegmentRomStart)) {
 		scroll_textures_pss();
 	}
-
-	if(SCROLL_CONDITION(sSegmentROMTable[0x7] == (uintptr_t)_pss_segment_7SegmentRomStart)) {
-		scroll_textures_pss();
-	}
-
-	if(SCROLL_CONDITION(sSegmentROMTable[0x7] == (uintptr_t)_pss_segment_7SegmentRomStart)) {
-		scroll_textures_pss();
-	}
-
 }

--- a/src/menu/cozy_file_select.h
+++ b/src/menu/cozy_file_select.h
@@ -16,6 +16,7 @@ typedef s32 (*FileSelectOptionCallback)(struct _FileSelectMenuState *mState);
 
 typedef struct _FileSelectOption {
     char *label;
+    u8 *description;
     FileSelectOptionCallback onSelect;
     s8 disabled;
     EnumOption *enumOptions;
@@ -65,5 +66,8 @@ enum FileSelectMenuTypes {
     MENU_TYPE_NUMBERED,
 };
 
+extern s32 gRenderingFileSelect;
+
 void init_file_select(void);
 s32 run_file_select(void);
+void render_file_select(void);

--- a/src/menu/file_select.c
+++ b/src/menu/file_select.c
@@ -2326,6 +2326,7 @@ void print_file_select_strings(void) {
 Gfx *geo_file_select_strings_and_menu_cursor(s32 callContext, UNUSED struct GraphNode *node, UNUSED Mat4 mtx) {
     if (callContext == GEO_CONTEXT_RENDER) {
         sSelectedFileNum = run_file_select();
+        gRenderingFileSelect = sSelectedFileNum == 0;
     } else if (callContext == GEO_CONTEXT_CREATE) {
         sSelectedFileNum = 0;
         init_file_select();


### PR DESCRIPTION
- fix crash on console
- disable USE_GAMECUBE_CONTROLLER (needed for some flashcarts - we still support GC, its just a rom header thang)
- removed the extra tex scroll calls in pss (scrolling was stupid fast)
- some of the BST hurt warps were still 1 segment, fixed it