### PR TITLE
fix mm acorn star spawning while above a warp plane

### DIFF
--- a/src/game/behaviors/maple_objects.inc.c
+++ b/src/game/behaviors/maple_objects.inc.c
@@ -11,14 +11,17 @@ void bhv_cherry_tree_loop(void) {
     else {
         obj_scale_xyz(o, 1, 1, 1);
 
-        if (o->oTimer == 30) {
+        if (!o->oF4) {
             s16 remainingTriggers = count_objects_with_behavior(bhvTreeNut);
-             if (remainingTriggers == 0) {
-                struct Object *starObj = spawn_object_abs_with_rot(o, 0, MODEL_STAR, bhvStarSpawnCoordinates, gMarioObject->oPosX, gMarioObject->oPosY + 300, gMarioObject->oPosZ, 0, 0, 0);
-                starObj->oBehParams = 0x04010000;
-                starObj->oHomeX = starObj->oPosX;
-                starObj->oHomeY = starObj->oPosY;
-                starObj->oHomeZ = starObj->oPosZ;
+            if(!SURFACE_IS_WARP_PLANE(gMarioState->floor->type)) {
+                o->oF4 = 1;
+                if (remainingTriggers == 0) {
+                    struct Object *starObj = spawn_object_abs_with_rot(o, 0, MODEL_STAR, bhvStarSpawnCoordinates, gMarioObject->oPosX, gMarioObject->oPosY + 300, gMarioObject->oPosZ, 0, 0, 0);
+                    starObj->oBehParams = 0x04010000;
+                    starObj->oHomeX = starObj->oPosX;
+                    starObj->oHomeY = starObj->oPosY;
+                    starObj->oHomeZ = starObj->oPosZ;
+                }
             }
         }
     }


### PR DESCRIPTION
another small bug that you kinda have to go out of your way to encounter. if you make the star spawn while falling into a pit it would spawn a star in a hard to reach place, and it could keep the screen black during the star cutscene if it started while in the act_floor_checkpoint_warp_out action

now it just waits for when mario is on safe ground